### PR TITLE
Metabase環境を構築のテンプレートのos_typeをcentos7に修正する

### DIFF
--- a/tffile/metabase-centos.tf
+++ b/tffile/metabase-centos.tf
@@ -80,7 +80,7 @@ locals {
 
 # パブリックアーカイブ(OS)のID参照用のデータソース(CentOS7)
 data "sakuracloud_archive" "centos" {
-  os_type = "centos"
+  os_type = "centos7"
 }
 
 # ディスク


### PR DESCRIPTION
## 概要

現状のテンプレートではCentOSのパブリックアーカイブを取得できずエラーとなる問題がありました。

os_typeをcentos7に修正することでこの問題を回避しています。